### PR TITLE
Don't use gcc __builtin_ctzll() for 32 bit

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -259,7 +259,7 @@ inline Bitboard attacks_bb(Piece pc, Square s, Bitboard occupied) {
 
 /// lsb() and msb() return the least/most significant bit in a non-zero bitboard
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(IS_64BIT)
 
 inline Square lsb(Bitboard b) {
   assert(b);


### PR DESCRIPTION
Our software fallback is faster than gcc's one.

Tested at STC:
LLR: 2.97 (-2.94,2.94) [0.00,5.00]
Total: 28548 W: 5308 L: 5060 D: 18180

Patch suggested by Joona.

No functional change.