### PR TITLE
Bonus for pins on the opponent queen (exclude batteries)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -187,6 +187,7 @@ namespace {
   const Score OtherCheck          = S(10, 10);
   const Score ThreatByHangingPawn = S(71, 61);
   const Score LooseEnemies        = S( 0, 25);
+  const Score PinOnQueen          = S(50, 10);
   const Score Hanging             = S(48, 27);
   const Score ThreatByPawnPush    = S(38, 22);
   const Score Unstoppable         = S( 0, 20);
@@ -487,6 +488,10 @@ namespace {
     if (   (pos.pieces(Them) ^ pos.pieces(Them, QUEEN, KING))
         & ~(ei.attackedBy[Us][ALL_PIECES] | ei.attackedBy[Them][ALL_PIECES]))
         score += LooseEnemies;
+
+    // Bonus for pins on the opponent queen
+    if (pos.queen_pins(Them))
+        score += PinOnQueen;
 
     // Non-pawn enemies attacked by a pawn
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];

--- a/src/position.h
+++ b/src/position.h
@@ -145,6 +145,7 @@ public:
   // Piece specific
   bool pawn_passed(Color c, Square s) const;
   bool opposite_bishops() const;
+  Bitboard queen_pins(Color c) const;
 
   // Doing and undoing moves
   void do_move(Move m, StateInfo& st, bool givesCheck);
@@ -186,7 +187,7 @@ private:
   void set_state(StateInfo* si) const;
 
   // Other helpers
-  Bitboard check_blockers(Color c, Color kingColor) const;
+  Bitboard slider_blockers(Color c1, Square s, Color c2, bool onQueen = false) const;
   void put_piece(Color c, PieceType pt, Square s);
   void remove_piece(Color c, PieceType pt, Square s);
   void move_piece(Color c, PieceType pt, Square from, Square to);
@@ -311,11 +312,15 @@ inline Bitboard Position::checkers() const {
 }
 
 inline Bitboard Position::discovered_check_candidates() const {
-  return check_blockers(sideToMove, ~sideToMove);
+  return slider_blockers(sideToMove, square<KING>(~sideToMove), ~sideToMove);
 }
 
 inline Bitboard Position::pinned_pieces(Color c) const {
-  return check_blockers(c, c);
+  return slider_blockers(c, square<KING>(c), c);
+}
+
+inline Bitboard Position::queen_pins(Color c) const {
+  return pieceCount[c][QUEEN] ? slider_blockers(c, pieceList[c][QUEEN][0], c, true) : 0;
 }
 
 inline bool Position::pawn_passed(Color c, Square s) const {


### PR DESCRIPTION
Bonus for pins on the opponent queen (take 2).

This version excludes from the pinned pieces rook blockers which are
orthogonally pinned and bishop blockers which are diagonally pinned, as
these pieces are in fact part of a battery with the queen and thus may
be both a weakness and a strength.