### PR TITLE
Don't create/delete threads while searching

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -123,7 +123,7 @@ void Thread::idle_loop() {
 void ThreadPool::init() {
 
   push_back(new MainThread);
-  read_uci_options();
+  read_uci_threads_num();
 }
 
 
@@ -133,20 +133,24 @@ void ThreadPool::init() {
 
 void ThreadPool::exit() {
 
+  main()->wait_for_search_finished();
+
   while (size())
       delete back(), pop_back();
 }
 
 
-/// ThreadPool::read_uci_options() updates internal threads parameters from the
-/// corresponding UCI options and creates/destroys threads to match requested
+/// ThreadPool::read_uci_threads_num() updates internal threads parameters from
+/// the corresponding UCI options and creates/destroys threads to match requested
 /// number. Thread objects are dynamically allocated.
 
-void ThreadPool::read_uci_options() {
+void ThreadPool::read_uci_threads_num() {
 
   size_t requested = Options["Threads"];
 
   assert(requested > 0);
+
+  main()->wait_for_search_finished();
 
   while (size() < requested)
       push_back(new Thread);

--- a/src/thread.h
+++ b/src/thread.h
@@ -95,7 +95,7 @@ struct ThreadPool : public std::vector<Thread*> {
 
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
-  void read_uci_options();
+  void read_uci_threads_num();
   int64_t nodes_searched();
 
 private:

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -39,7 +39,7 @@ namespace UCI {
 void on_clear_hash(const Option&) { Search::clear(); }
 void on_hash_size(const Option& o) { TT.resize(o); }
 void on_logger(const Option& o) { start_logger(o); }
-void on_threads(const Option&) { Threads.read_uci_options(); }
+void on_threads(const Option&) { Threads.read_uci_threads_num(); }
 void on_tb_path(const Option& o) { Tablebases::init(o); }
 
 


### PR DESCRIPTION
This fixes a possible race reported by Mohammed Li in
case Threads[] array is changed while looping on it:

https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/h-G4I7nqHfw

Caveat: with this patch we can hang the GUI thread if we send something
like 'setoption name threads value 1' while searching, this in general
is not a problem, the engine will recover as soon as current search
finishes. The only case where we have a real hang is if we are doing
an infinite analysis with 'go infinite'. In this case the engine will
hang forever and user needs to CTRL+C the process.

No functional change.