### PR TITLE
Explicitly use alpha+1 for beta in NonPV search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -721,7 +721,7 @@ namespace {
         &&  eval + razor_margin[depth / ONE_PLY] <= alpha)
     {
         if (depth <= ONE_PLY)
-            return qsearch<NonPV, false>(pos, ss, alpha, beta);
+            return qsearch<NonPV, false>(pos, ss, alpha, alpha+1);
 
         Value ralpha = alpha - razor_margin[depth / ONE_PLY];
         Value v = qsearch<NonPV, false>(pos, ss, ralpha, ralpha+1);


### PR DESCRIPTION
fixes the only exception, in razoring.

The code already does assert(PvNode || (alpha == beta - 1)), and it can be verified by studying the program flow that this is indeed the case, also for the modified line.

No functional change.