### PR TITLE
Reintroduce depth 2 razor pruning with additional margins

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -66,8 +66,10 @@ namespace {
   const int SkipSize[]  = { 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4 };
   const int SkipPhase[] = { 0, 1, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7 };
 
-  // Razoring and futility margins
-  const int RazorMargin = 590;
+  // Razor and futility margins
+  const int RazorMargin1 = 590;
+  const int RazorMargin2 = 614;
+  const int RazorMargin2r = 594;
   Value futility_margin(Depth d) { return Value(150 * d / ONE_PLY); }
 
   // Futility and reductions lookup tables, initialized at startup
@@ -667,9 +669,20 @@ namespace {
 
     // Step 7. Razoring (skipped when in check)
     if (   !PvNode
-        &&  depth <= ONE_PLY
-        &&  eval + RazorMargin <= alpha)
-        return qsearch<NonPV, false>(pos, ss, alpha, alpha+1);
+        &&  depth <= ONE_PLY)
+    {
+        if (eval + RazorMargin1 <= alpha)
+            return qsearch<NonPV, false>(pos, ss, alpha, alpha+1);
+    }
+    else if (   !PvNode
+             &&  depth <= 2 * ONE_PLY
+             &&  eval + RazorMargin2 <= alpha)
+    {
+        Value ralpha = alpha - RazorMargin2r;
+        Value v = qsearch<NonPV, false>(pos, ss, ralpha, ralpha+1);
+        if (v <= ralpha)
+            return v;
+    }
 
     // Step 8. Futility pruning: child node (skipped when in check)
     if (   !rootNode


### PR DESCRIPTION
The first depth 2 margin triggers the verification qsearch().
This qsearch() result has to be better then the second lower margin,
so we only skip the razoring when the qsearch gives a significant improvement.

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 32133 W: 7395 L: 7101 D: 17637
http://tests.stockfishchess.org/tests/view/5a93198b0ebc590297cc8942

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 17382 W: 3002 L: 2809 D: 11571
http://tests.stockfishchess.org/tests/view/5a93b18c0ebc590297cc89c2

bench: 5727474