### PR TITLE
Simplify evaluation of blockers_for_king

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -477,7 +477,7 @@ namespace {
         kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                      +  69 * kingAttacksCount[Them]
                      + 185 * popcount(kingRing[Us] & weak)
-                     + 129 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
+                     + 150 * popcount(pos.blockers_for_king(Us) | unsafeChecks)
                      +   4 * tropism
                      - 873 * !pos.count<QUEEN>(Them)
                      -   6 * mg_value(score) / 8
@@ -545,9 +545,6 @@ namespace {
             score += ThreatByMinor[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
-
-            else if (pos.blockers_for_king(Them) & s)
-                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         b = weak & attackedBy[Us][ROOK];
@@ -557,9 +554,6 @@ namespace {
             score += ThreatByRook[type_of(pos.piece_on(s))];
             if (type_of(pos.piece_on(s)) != PAWN)
                 score += ThreatByRank * (int)relative_rank(Them, s);
-
-            else if (pos.blockers_for_king(Them) & s)
-                score += ThreatByRank * (int)relative_rank(Them, s) / 2;
         }
 
         if (weak & attackedBy[Us][KING])


### PR DESCRIPTION
Currently, we have two evaluation terms which account for pinned pieces.
One is for all pinned pieces in kingDanger computation and another for
just pinned pawns in ThreatByRank. We can increase the relevant bonus
for kingDanger calculation and do away with the ThreatByRank, which
seems to just add more complexity.

STC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 113353 W: 24299 L: 24356 D: 64698
http://tests.stockfishchess.org/tests/view/5ba348c20ebc592cf2766e61

LTC:
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 96458 W: 15514 L: 15511 D: 65433
http://tests.stockfishchess.org/tests/view/5ba398830ebc592cf2767563

At 100k games, I thought it struggles a bit, but some related [0,4]
tests attempting individual tweaks seem to fail:

I tried directly tweaking ThreatByRank:
http://tests.stockfishchess.org/tests/view/5ba3c6300ebc592cf276791c
http://tests.stockfishchess.org/tests/view/5ba3c6190ebc592cf2767917

@Vizveznedec was also recently trying to tweak the same coeffecients
for kingDanger calculation:
http://tests.stockfishchess.org/tests/view/5ba2c7320ebc592cf27664b2
http://tests.stockfishchess.org/tests/view/5ba2c8220ebc592cf27664b8
http://tests.stockfishchess.org/tests/view/5ba2c7880ebc592cf27664b4
http://tests.stockfishchess.org/tests/view/5ba2c7ce0ebc592cf27664b6

Bench: 4119925