### PR TITLE
Correctly track down pv even in fail-high case

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1129,6 +1129,8 @@ moves_loop: // When in check, search starts from here
                   break;
               }
           }
+          else if (PvNode && !rootNode && value == alpha)
+              update_pv(ss->pv, move, (ss+1)->pv);
       }
 
       if (move != bestMove)


### PR DESCRIPTION
Currently we update (track up) the pv even in the fail high case.
However most times in such cases the pv in the ply below remains unset
because there we have value == alpha and so finally we see truncated
pv's (=just one move) in fail high cases.
Of course tracking down these pv's (+sending them to the gui) comes at a
certian cost, but no-regression tests passed:

STC:
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 16300 W: 3556 L: 3424 D: 9320
http://tests.stockfishchess.org/tests/view/5b9b73500ebc592cf275ea92

LTC: 
LLR: 2.96 (-2.94,2.94) [-3.00,1.00]
Total: 202411 W: 32734 L: 32897 D: 136780 
http://tests.stockfishchess.org/tests/view/5b9baed10ebc592cf275ef6d

N.B.: Digging also into qsearch was tried in another version but seemed
not to pass the tests. This means that we don't always will get a pv
until the very tips.

no functional change
bench: 4248710